### PR TITLE
Implement AUTH command

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,38 @@
+// Copyright 2018-2025 The Olric Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package olric
+
+import (
+	"github.com/olric-data/olric/internal/protocol"
+	"github.com/olric-data/olric/internal/server"
+	"github.com/tidwall/redcon"
+)
+
+func (db *Olric) authCommandHandler(conn redcon.Conn, cmd redcon.Command) {
+	authCmd, err := protocol.ParseAuthCommand(cmd)
+	if err != nil {
+		protocol.WriteError(conn, err)
+		return
+	}
+
+	if authCmd.Username == db.config.Authentication.Username && authCmd.Password == db.config.Authentication.Password {
+		ctx := conn.Context().(*server.ConnContext)
+		ctx.SetAuthenticated(true)
+		conn.WriteString(protocol.StatusOK)
+		return
+	}
+
+	protocol.WriteError(conn, ErrWrongPass)
+}

--- a/auth.go
+++ b/auth.go
@@ -20,6 +20,7 @@ import (
 	"github.com/tidwall/redcon"
 )
 
+// authCommandHandler handles the authentication command by validating provided credentials against configured values.
 func (db *Olric) authCommandHandler(conn redcon.Conn, cmd redcon.Command) {
 	authCmd, err := protocol.ParseAuthCommand(cmd)
 	if err != nil {

--- a/auth_test.go
+++ b/auth_test.go
@@ -1,0 +1,59 @@
+// Copyright 2018-2025 The Olric Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package olric
+
+import (
+	"context"
+	"testing"
+
+	"github.com/olric-data/olric/config"
+	"github.com/olric-data/olric/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthCommandHandler_WithCredentials(t *testing.T) {
+	cluster := newTestOlricCluster(t)
+	testConfig := testutil.NewConfig()
+	testConfig.Authentication = &config.Authentication{
+		Enabled:  true,
+		Username: "test-user",
+		Password: "test-password",
+	}
+	db := cluster.addMemberWithConfig(t, testConfig)
+
+	expectedMessage := "error while discovering the cluster members: invalid username-password pair or user is disabled"
+	ctx := context.Background()
+	t.Run("With correct credentials", func(t *testing.T) {
+		c, err := NewClusterClient([]string{db.name}, WithCredentials("test-user", "test-password"))
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, c.Close(ctx))
+		}()
+
+		response, err := c.Ping(ctx, db.rt.This().String(), "")
+		require.NoError(t, err)
+		require.Equal(t, DefaultPingResponse, response)
+	})
+
+	t.Run("With wrong credentials", func(t *testing.T) {
+		_, err := NewClusterClient([]string{db.name}, WithCredentials("wrong", "wrong"))
+		require.ErrorContains(t, err, expectedMessage)
+	})
+
+	t.Run("Without credentials", func(t *testing.T) {
+		_, err := NewClusterClient([]string{db.name}, WithCredentials("wrong", "wrong"))
+		require.ErrorContains(t, err, expectedMessage)
+	})
+}

--- a/cluster_client.go
+++ b/cluster_client.go
@@ -699,6 +699,7 @@ type ClusterClientOption func(c *clusterClientConfig)
 type clusterClientConfig struct {
 	logger                    *log.Logger
 	config                    *config.Client
+	authentication            *config.Authentication
 	hasher                    hasher.Hasher
 	routingTableFetchInterval time.Duration
 }
@@ -718,6 +719,16 @@ func WithLogger(l *log.Logger) ClusterClientOption {
 func WithConfig(c *config.Client) ClusterClientOption {
 	return func(cfg *clusterClientConfig) {
 		cfg.config = c
+	}
+}
+
+func WithCredentials(username, password string) ClusterClientOption {
+	return func(cfg *clusterClientConfig) {
+		cfg.authentication = &config.Authentication{
+			Enabled:  true,
+			Username: username,
+			Password: password,
+		}
 	}
 }
 
@@ -787,6 +798,10 @@ func NewClusterClient(addresses []string, options ...ClusterClientOption) (*Clus
 
 	if cc.config == nil {
 		cc.config = config.NewClient()
+	}
+
+	if cc.authentication != nil {
+		cc.config.Authentication = cc.authentication
 	}
 
 	if cc.routingTableFetchInterval <= 0 {

--- a/cmd/olric-server/olric-server-local.yaml
+++ b/cmd/olric-server/olric-server-local.yaml
@@ -64,6 +64,11 @@ server:
   # cluster.events channel. Default is false.
   enableClusterEventsChannel: true
 
+authentication:
+  enabled: true
+  username: "foobar"
+  password: "secret"
+  
 client:
   # Timeout for TCP dial.
   #

--- a/cmd/olric-server/olric-server-local.yaml
+++ b/cmd/olric-server/olric-server-local.yaml
@@ -65,9 +65,9 @@ server:
   enableClusterEventsChannel: true
 
 authentication:
-  enabled: true
-  username: "foobar"
-  password: "secret"
+  enabled: false
+  username: "your-username"
+  password: "your-password"
   
 client:
   # Timeout for TCP dial.

--- a/config/authentication.go
+++ b/config/authentication.go
@@ -1,0 +1,43 @@
+// Copyright 2018-2025 The Olric Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "errors"
+
+type Authentication struct {
+	Enabled  bool
+	Username string
+	Password string
+}
+
+func (a *Authentication) Sanitize() error {
+	// Nothing to do
+	return nil
+}
+
+func (a *Authentication) Validate() error {
+	if a.Enabled {
+		if a.Username == "" {
+			return errors.New("if authentication is enabled, username cannot be empty")
+		}
+		if a.Password == "" {
+			return errors.New("if authentication is enabled, password cannot be empty")
+		}
+	}
+	return nil
+}
+
+// Interface guard
+var _ IConfig = (*Authentication)(nil)

--- a/config/authentication.go
+++ b/config/authentication.go
@@ -16,17 +16,20 @@ package config
 
 import "errors"
 
+// Authentication represents configuration settings for enabling and managing user authentication.
 type Authentication struct {
 	Enabled  bool
 	Username string
 	Password string
 }
 
+// Sanitize ensures the Authentication configuration is pre-processed and prepared for use, with no changes currently applied.
 func (a *Authentication) Sanitize() error {
 	// Nothing to do
 	return nil
 }
 
+// Validate checks if the Authentication configuration is valid, ensuring username and password are set if enabled.
 func (a *Authentication) Validate() error {
 	if a.Enabled {
 		if a.Username == "" {

--- a/config/client.go
+++ b/config/client.go
@@ -37,6 +37,8 @@ const (
 
 // Client denotes configuration for TCP clients in Olric and the official Golang client.
 type Client struct {
+	Authentication *Authentication
+
 	// Dial timeout for establishing new connections.
 	// Default is 5 seconds.
 	DialTimeout time.Duration
@@ -106,7 +108,9 @@ type Client struct {
 
 // NewClient returns a new configuration object for clients.
 func NewClient() *Client {
-	c := &Client{}
+	c := &Client{
+		Authentication: &Authentication{},
+	}
 	err := c.Sanitize()
 	if err != nil {
 		panic(fmt.Sprintf("failed to create a new client configuration: %v", err))
@@ -116,6 +120,10 @@ func NewClient() *Client {
 
 // Sanitize sets default values to empty configuration variables, if it's possible.
 func (c *Client) Sanitize() error {
+	if err := c.Authentication.Sanitize(); err != nil {
+		return fmt.Errorf("failed to sanitize authentication configuration: %w", err)
+	}
+
 	if c.DialTimeout == 0 {
 		c.DialTimeout = DefaultDialTimeout
 	}
@@ -175,12 +183,17 @@ func (c *Client) Sanitize() error {
 }
 
 // Validate finds errors in the current configuration.
-func (c *Client) Validate() error { return nil }
+func (c *Client) Validate() error {
+	if err := c.Authentication.Validate(); err != nil {
+		return fmt.Errorf("failed to validate authentication configuration: %w", err)
+	}
+	return nil
+}
 
 func (c *Client) RedisOptions() *redis.Options {
 	// Note: IdleCheckFrequency is gone since go-redis no longer checks idle connections.
 	// See https://github.com/redis/go-redis/discussions/2635
-	return &redis.Options{
+	options := &redis.Options{
 		Network:         "tcp",
 		Dialer:          c.Dialer,
 		OnConnect:       c.OnConnect,
@@ -199,6 +212,11 @@ func (c *Client) RedisOptions() *redis.Options {
 		TLSConfig:       c.TLSConfig,
 		Limiter:         c.Limiter,
 	}
+	if c.Authentication.Enabled {
+		options.Username = c.Authentication.Username
+		options.Password = c.Authentication.Password
+	}
+	return options
 }
 
 // Interface guard

--- a/config/config.go
+++ b/config/config.go
@@ -15,6 +15,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -163,8 +164,16 @@ const (
 	DefaultKeepAlivePeriod = 300 * time.Second
 )
 
+type Authentication struct {
+	Enabled  bool
+	Username string
+	Password string
+}
+
 // Config is the configuration to create a Olric instance.
 type Config struct {
+	Authentication *Authentication
+
 	// Interface denotes a binding interface. It can be used instead of BindAddr
 	// if the interface is known but not the address. If both are provided, then
 	// Olric verifies that the interface has the bind address that is provided.
@@ -374,6 +383,15 @@ func (c *Config) Validate() error {
 		return err
 	}
 
+	if c.Authentication.Enabled {
+		if c.Authentication.Username == "" {
+			return errors.New("if authentication is enabled, username cannot be empty")
+		}
+		if c.Authentication.Password == "" {
+			return errors.New("if authentication is enabled, password cannot be empty")
+		}
+	}
+
 	switch c.LogLevel {
 	case LogLevelDebug, LogLevelWarn, LogLevelInfo, LogLevelError:
 	default:
@@ -530,6 +548,7 @@ func New(env string) *Config {
 		MemberCountQuorum: 1,
 		Peers:             []string{},
 		DMaps:             &DMaps{},
+		Authentication:    &Authentication{},
 	}
 
 	m, err := NewMemberlistConfig(env)

--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -163,12 +162,6 @@ const (
 	// connection closed events.
 	DefaultKeepAlivePeriod = 300 * time.Second
 )
-
-type Authentication struct {
-	Enabled  bool
-	Username string
-	Password string
-}
 
 // Config is the configuration to create a Olric instance.
 type Config struct {
@@ -380,16 +373,11 @@ func (c *Config) Validate() error {
 	}
 
 	if err := c.DMaps.Validate(); err != nil {
-		return err
+		return fmt.Errorf("failed to validate DMap configuration: %w", err)
 	}
 
-	if c.Authentication.Enabled {
-		if c.Authentication.Username == "" {
-			return errors.New("if authentication is enabled, username cannot be empty")
-		}
-		if c.Authentication.Password == "" {
-			return errors.New("if authentication is enabled, password cannot be empty")
-		}
+	if err := c.Authentication.Validate(); err != nil {
+		return fmt.Errorf("failed to sanitize authentication configuration: %w", err)
 	}
 
 	switch c.LogLevel {
@@ -499,6 +487,14 @@ func (c *Config) Sanitize() error {
 
 	if c.DMaps == nil {
 		c.DMaps = &DMaps{}
+	}
+
+	if c.Authentication == nil {
+		c.Authentication = &Authentication{}
+	}
+
+	if err := c.Authentication.Sanitize(); err != nil {
+		return fmt.Errorf("failed to sanitize authentication configuration: %w", err)
 	}
 
 	if err := c.Client.Sanitize(); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -40,6 +40,12 @@ var testConfig = `server:
   memberCountQuorum: 1
   enableClusterEventsChannel: true
 
+
+authentication:
+  enabled: true
+  username: "foobar"
+  password: "secret"
+
 client:
   dialTimeout: 8s
   readTimeout: 2s
@@ -213,6 +219,12 @@ func TestConfig(t *testing.T) {
 	c.ServiceDiscovery["replaceExistingChecks"] = true
 	c.ServiceDiscovery["insecureSkipVerify"] = true
 	c.ServiceDiscovery["payload"] = "SAMPLE-PAYLOAD"
+
+	c.Authentication = &Authentication{
+		Enabled:  true,
+		Username: "foobar",
+		Password: "secret",
+	}
 
 	err = c.Sanitize()
 	require.NoError(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -225,6 +225,7 @@ func TestConfig(t *testing.T) {
 		Username: "foobar",
 		Password: "secret",
 	}
+	c.Client.Authentication = c.Authentication
 
 	err = c.Sanitize()
 	require.NoError(t, err)

--- a/config/internal/loader/loader.go
+++ b/config/internal/loader/loader.go
@@ -38,6 +38,12 @@ type server struct {
 	EnableClusterEventsChannel bool    `yaml:"enableClusterEventsChannel"`
 }
 
+type authentication struct {
+	Enabled  bool   `yaml:"enabled"`
+	Username string `yaml:"username"`
+	Password string `yaml:"password"`
+}
+
 type client struct {
 	DialTimeout     string `yaml:"dialTimeout"`
 	ReadTimeout     string `yaml:"readTimeout"`
@@ -130,6 +136,7 @@ type Loader struct {
 	Client           client           `yaml:"client"`
 	DMaps            dmaps            `yaml:"dmaps"`
 	ServiceDiscovery serviceDiscovery `yaml:"serviceDiscovery"`
+	Authentication   authentication   `yaml:"authentication"`
 }
 
 // New tries to read Olric configuration from a YAML file.

--- a/config/load.go
+++ b/config/load.go
@@ -362,7 +362,13 @@ func Load(filename string) (*Config, error) {
 		}
 	}
 
-	clientConfig := Client{}
+	clientConfig := Client{
+		Authentication: &Authentication{
+			Enabled:  c.Authentication.Enabled,
+			Username: c.Authentication.Username,
+			Password: c.Authentication.Password,
+		},
+	}
 	err = mapYamlToConfig(&clientConfig, &c.Client)
 	if err != nil {
 		return nil, err

--- a/config/load.go
+++ b/config/load.go
@@ -405,6 +405,11 @@ func Load(filename string) (*Config, error) {
 		BootstrapTimeout:           bootstrapTimeout,
 		LeaveTimeout:               leaveTimeout,
 		DMaps:                      dmapConfig,
+		Authentication: &Authentication{
+			Enabled:  c.Authentication.Enabled,
+			Username: c.Authentication.Username,
+			Password: c.Authentication.Password,
+		},
 	}
 
 	if err := cfg.Sanitize(); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -11,14 +11,14 @@ require (
 	github.com/hashicorp/logutils v1.0.0
 	github.com/hashicorp/memberlist v0.5.3
 	github.com/pkg/errors v0.9.1
-	github.com/redis/go-redis/v9 v9.7.3
+	github.com/redis/go-redis/v9 v9.8.0
 	github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529
 	github.com/stretchr/testify v1.10.0
 	github.com/tidwall/btree v1.7.0
 	github.com/tidwall/match v1.1.1
 	github.com/tidwall/redcon v1.6.2
 	github.com/vmihailenco/msgpack/v5 v5.4.1
-	golang.org/x/sync v0.13.0
+	golang.org/x/sync v0.14.0
 	gopkg.in/yaml.v2 v2.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -135,8 +135,8 @@ github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsT
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
-github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
-github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
+github.com/redis/go-redis/v9 v9.8.0 h1:q3nRvjrlge/6UD7eTu/DSg2uYiU2mCL0G/uzBWqhicI=
+github.com/redis/go-redis/v9 v9.8.0/go.mod h1:huWgSWd8mW6+m0VPhJjSSQ+d6Nh1VICQ6Q5lHuCH/Iw=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529 h1:nn5Wsu0esKSJiIVhscUtVbo7ada43DJhG55ua/hjS5I=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -180,8 +180,8 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.13.0 h1:AauUjRAJ9OSnvULf/ARrrVywoJDy0YS2AwQ98I37610=
-golang.org/x/sync v0.13.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/sync v0.14.0 h1:woo0S4Yywslg6hp4eUFjTVOyKt0RookbpAHG4c1HmhQ=
+golang.org/x/sync v0.14.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/cluster/routingtable/routingtable.go
+++ b/internal/cluster/routingtable/routingtable.go
@@ -395,12 +395,12 @@ func (r *RoutingTable) Start() error {
 	ctx, cancel := context.WithTimeout(r.ctx, time.Hour)
 	defer cancel()
 	err := r.tryWithInterval(ctx, time.Second, func() error {
-		// Check member count quorum now. If there is no enough peers to work, wait forever.
+		// Check member count quorum now. If there are not enough peers to work, wait forever.
 		err := r.CheckMemberCountQuorum()
 		if err != nil {
 			r.log.V(2).Printf("[ERROR] Inoperable node: %v", err)
 		}
-		return err
+		return nil
 	})
 	if err != nil {
 		return err

--- a/internal/cluster/routingtable/update.go
+++ b/internal/cluster/routingtable/update.go
@@ -85,7 +85,7 @@ func (r *RoutingTable) updateRoutingTableOnCluster() (map[discovery.Member]*left
 	r.Members().Range(func(id uint64, tmp discovery.Member) bool {
 		member := tmp
 		g.Go(func() error {
-			if err := sem.Acquire(r.ctx, 1); err != nil {
+			if err = sem.Acquire(r.ctx, 1); err != nil {
 				r.log.V(3).Printf("[ERROR] Failed to acquire semaphore to update routing table on %s: %v", member, err)
 				return err
 			}

--- a/internal/protocol/commands.go
+++ b/internal/protocol/commands.go
@@ -95,6 +95,7 @@ var DMap = &DMapCommands{
 }
 
 type PubSubCommands struct {
+	PubSub          string
 	Publish         string
 	PublishInternal string
 	Subscribe       string
@@ -105,6 +106,7 @@ type PubSubCommands struct {
 }
 
 var PubSub = &PubSubCommands{
+	PubSub:          "pubsub",
 	Publish:         "publish",
 	PublishInternal: "publish.internal",
 	Subscribe:       "subscribe",

--- a/internal/protocol/commands.go
+++ b/internal/protocol/commands.go
@@ -42,11 +42,13 @@ var Internal = &InternalCommands{
 type GenericCommands struct {
 	Ping  string
 	Stats string
+	Auth  string
 }
 
 var Generic = &GenericCommands{
 	Ping:  "ping",
 	Stats: "stats",
+	Auth:  "auth",
 }
 
 type DMapCommands struct {

--- a/internal/protocol/system.go
+++ b/internal/protocol/system.go
@@ -202,3 +202,36 @@ func ParseStatsCommand(cmd redcon.Command) (*Stats, error) {
 
 	return s, nil
 }
+
+type Auth struct {
+	Username string
+	Password string
+}
+
+func NewAuth(username, password string) *Auth {
+	return &Auth{
+		Username: username,
+		Password: password,
+	}
+}
+
+func (a *Auth) Command(ctx context.Context) *redis.StatusCmd {
+	var args []interface{}
+
+	args = append(args, Generic.Auth)
+	args = append(args, a.Username)
+	args = append(args, a.Password)
+
+	return redis.NewStatusCmd(ctx, args...)
+}
+
+func ParseAuthCommand(cmd redcon.Command) (*Auth, error) {
+	if len(cmd.Args) != 3 {
+		return nil, errWrongNumber(cmd.Args)
+	}
+
+	return NewAuth(
+		util.BytesToString(cmd.Args[1]),
+		util.BytesToString(cmd.Args[2]),
+	), nil
+}

--- a/internal/protocol/system_test.go
+++ b/internal/protocol/system_test.go
@@ -106,3 +106,21 @@ func TestProtocol_Stats_CR(t *testing.T) {
 
 	require.True(t, parsed.CollectRuntime)
 }
+
+func TestProtocol_Auth(t *testing.T) {
+	auth := NewAuth("foobar", "secret")
+
+	cmd := stringToCommand(auth.Command(context.Background()).String())
+	parsed, err := ParseAuthCommand(cmd)
+	require.NoError(t, err)
+
+	require.Equal(t, "foobar", parsed.Username)
+	require.Equal(t, "secret", parsed.Password)
+}
+
+func TestProtocol_Auth_errWrongNumber(t *testing.T) {
+	cmd := stringToCommand("auth foobar:")
+
+	_, err := ParseAuthCommand(cmd)
+	require.Equal(t, "wrong number of arguments for 'auth foobar' command", err.Error())
+}

--- a/internal/server/client.go
+++ b/internal/server/client.go
@@ -16,6 +16,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
@@ -52,7 +53,7 @@ func (c *Client) Addresses() map[string]struct{} {
 	defer c.mu.RUnlock()
 
 	addresses := make(map[string]struct{})
-	for address, _ := range c.clients {
+	for address := range c.clients {
 		addresses[address] = struct{}{}
 	}
 	return addresses
@@ -92,7 +93,7 @@ func (c *Client) pickNodeRoundRobin() (string, error) {
 	defer c.mu.RUnlock()
 
 	addr, err := c.roundRobin.Get()
-	if err == roundrobin.ErrEmptyInstance {
+	if errors.Is(err, roundrobin.ErrEmptyInstance) {
 		return "", fmt.Errorf("no available client found")
 	}
 	if err != nil {

--- a/internal/server/client.go
+++ b/internal/server/client.go
@@ -79,6 +79,7 @@ func (c *Client) Get(addr string) *redis.Client {
 	}
 
 	opt := c.config.RedisOptions()
+	opt.Protocol = 2
 	opt.Addr = addr
 	rc = redis.NewClient(opt)
 	c.clients[addr] = rc

--- a/internal/server/mux.go
+++ b/internal/server/mux.go
@@ -31,6 +31,7 @@ import (
 	"github.com/tidwall/redcon"
 )
 
+// errAuthRequired represents an error indicating that authentication is required to access the requested resource or operation.
 var errAuthRequired = errors.New("authentication required")
 
 // ServeMux is an RESP command multiplexer.

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -113,3 +113,13 @@ func TestServer_RESP_Stats(t *testing.T) {
 	require.NotEqual(t, int64(0), WrittenBytesTotal.Read())
 	require.NotEqual(t, int64(0), ReadBytesTotal.Read())
 }
+
+func TestConnContext_Authentication(t *testing.T) {
+	ctx := NewConnContext()
+	require.False(t, ctx.IsAuthenticated())
+
+	t.Run("Authenticated", func(t *testing.T) {
+		ctx.SetAuthenticated(true)
+		require.True(t, ctx.IsAuthenticated())
+	})
+}

--- a/olric-server-docker.yaml
+++ b/olric-server-docker.yaml
@@ -61,6 +61,11 @@ server:
   # cluster.events channel. Default is false.
   enableClusterEventsChannel: true
 
+authentication:
+  enabled: false
+  username: "your-username"
+  password: "your-password"
+
 client:
   # Timeout for TCP dial.
   #

--- a/olric.go
+++ b/olric.go
@@ -212,6 +212,9 @@ func New(c *config.Config) (*Olric, error) {
 	}
 	e.Set("logger", flogger)
 
+	if c.Authentication.Enabled {
+		c.Client.Authentication = c.Authentication
+	}
 	client := server.NewClient(c.Client)
 	e.Set("client", client)
 	e.Set("primary", partitions.New(c.PartitionCount, partitions.PRIMARY))

--- a/olric.go
+++ b/olric.go
@@ -97,6 +97,8 @@ var (
 	// ErrConnRefused returned if the target node refused a connection request.
 	// It is good to call RefreshMetadata to update the underlying data structures.
 	ErrConnRefused = errors.New("connection refused")
+
+	ErrWrongPass = errors.New("invalid username-password pair or user is disabled")
 )
 
 // Olric implements a distributed cache and in-memory key/value data store.
@@ -234,6 +236,7 @@ func New(c *config.Config) (*Olric, error) {
 		BindAddr:        c.BindAddr,
 		BindPort:        c.BindPort,
 		KeepAlivePeriod: c.KeepAlivePeriod,
+		RequireAuth:     c.Authentication.Enabled,
 	}
 	srv := server.New(rc, flogger)
 	srv.SetPreConditionFunc(db.preconditionFunc)
@@ -247,6 +250,7 @@ func New(c *config.Config) (*Olric, error) {
 	}
 
 	db.registerCommandHandlers()
+	registerErrors()
 
 	return db, nil
 }
@@ -265,6 +269,7 @@ func (db *Olric) registerCommandHandlers() {
 	db.server.ServeMux().HandleFunc(protocol.Cluster.RoutingTable, db.clusterRoutingTableCommandHandler)
 	db.server.ServeMux().HandleFunc(protocol.Generic.Stats, db.statsCommandHandler)
 	db.server.ServeMux().HandleFunc(protocol.Cluster.Members, db.clusterMembersCommandHandler)
+	db.server.ServeMux().HandleFunc(protocol.Generic.Auth, db.authCommandHandler)
 }
 
 // callStartedCallback checks passed checkpoint count and calls the callback
@@ -481,4 +486,8 @@ func convertDMapError(err error) error {
 	default:
 		return convertClusterError(err)
 	}
+}
+
+func registerErrors() {
+	protocol.SetError("WRONGPASS", ErrWrongPass)
 }

--- a/olric.go
+++ b/olric.go
@@ -88,7 +88,7 @@ var (
 	ErrClusterQuorum = errors.New("failed to find enough peers to create quorum")
 
 	// ErrKeyTooLarge means that the given key is too large to process.
-	// Maximum length of a key is 256 bytes.
+	// The maximum length of a key is 256 bytes.
 	ErrKeyTooLarge = errors.New("key too large")
 
 	// ErrEntryTooLarge returned if the required space for an entry is bigger than table size.
@@ -98,6 +98,7 @@ var (
 	// It is good to call RefreshMetadata to update the underlying data structures.
 	ErrConnRefused = errors.New("connection refused")
 
+	// ErrWrongPass represents an error indicating an invalid username-password pair or a disabled user.
 	ErrWrongPass = errors.New("invalid username-password pair or user is disabled")
 )
 
@@ -488,6 +489,7 @@ func convertDMapError(err error) error {
 	}
 }
 
+// registerErrors registers application-specific errors with their corresponding prefixes in the error management system.
 func registerErrors() {
 	protocol.SetError("WRONGPASS", ErrWrongPass)
 }


### PR DESCRIPTION
This PR provides an implementation Redis-style `AUTH` command.

Supported by cluster client:

```go
func WithCredentials(username, password string) ClusterClientOption {
	return func(cfg *clusterClientConfig) {
		cfg.authentication = &config.Authentication{
			Enabled:  true,
			Username: username,
			Password: password,
		}
	}
}
```

Embedded client is authenticated by default. 

The configuration is quite simple: 

```yaml
authentication:
  enabled: false
  username: "your-username"
  password: "your-password"
```

Olric returns the following error if the client is unauthorized:

```
(error) NOAUTH authentication required
```