### PR TITLE
Fix conflict between "not exist" and expiration options.

### DIFF
--- a/internal/dmap/put_handlers.go
+++ b/internal/dmap/put_handlers.go
@@ -40,6 +40,9 @@ func (s *Service) putCommandHandler(conn redcon.Conn, cmd redcon.Command) {
 		pc.HasNX = true
 	case putCmd.XX:
 		pc.HasXX = true
+	}
+
+	switch {
 	case putCmd.EX != 0:
 		pc.HasEX = true
 		pc.EX = time.Duration(putCmd.EX * float64(time.Second))


### PR DESCRIPTION
Problem:
NX & XX options are conflicting with expiration options (e.g. EX and PX,) when written to other cluster members.

Solution:
Fixed DMap service PUT handlers to handle those options separately as everywhere else.