### PR TITLE
Fix data race in internal/cluster/routingtable/update.go

### DIFF
--- a/internal/cluster/routingtable/update.go
+++ b/internal/cluster/routingtable/update.go
@@ -85,7 +85,7 @@ func (r *RoutingTable) updateRoutingTableOnCluster() (map[discovery.Member]*left
 	r.Members().Range(func(id uint64, tmp discovery.Member) bool {
 		member := tmp
 		g.Go(func() error {
-			if err = sem.Acquire(r.ctx, 1); err != nil {
+			if err := sem.Acquire(r.ctx, 1); err != nil {
 				r.log.V(3).Printf("[ERROR] Failed to acquire semaphore to update routing table on %s: %v", member, err)
 				return err
 			}


### PR DESCRIPTION
There is a data race between routing tables update go-routines when tests are ran with `-race` flag:
```
WARNING: DATA RACE
Write at 0x00c00040ec20 by goroutine 298:
  github.com/olric-data/olric/internal/cluster/routingtable.(*RoutingTable).updateRoutingTableOnCluster.(*Members).Range.(*RoutingTable).updateRoutingTableOnCluster.func1.func2()
      /home/maxim/.local/go/pkg/mod/github.com/olric-data/olric@v0.7.0/internal/cluster/routingtable/update.go:88 +0xeb
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/maxim/.local/go/pkg/mod/golang.org/x/sync@v0.16.0/errgroup/errgroup.go:93 +0x86

Previous read at 0x00c00040ec20 by goroutine 297:
  github.com/olric-data/olric/internal/cluster/routingtable.(*RoutingTable).updateRoutingTableOnCluster.(*Members).Range.(*RoutingTable).updateRoutingTableOnCluster.func1.func2()
      /home/maxim/.local/go/pkg/mod/github.com/olric-data/olric@v0.7.0/internal/cluster/routingtable/update.go:88 +0x12f
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /home/maxim/.local/go/pkg/mod/golang.org/x/sync@v0.16.0/errgroup/errgroup.go:93 +0x86
```

Same captured `err` variable is shared between several go-routines.