### PR TITLE
add: mget using repeated gets

### DIFF
--- a/internal/dmap/mget.go
+++ b/internal/dmap/mget.go
@@ -1,0 +1,17 @@
+package dmap
+
+import "context"
+
+func (dm *DMap) MGet(ctx context.Context, keys ...string) map[string][]byte {
+	result := make(map[string][]byte)
+
+	for _, key := range keys {
+		entry, err := dm.Get(ctx, key)
+
+		if err == nil {
+			result[key] = entry.Value()
+		}
+	}
+
+	return result
+}

--- a/internal/dmap/mget_test.go
+++ b/internal/dmap/mget_test.go
@@ -1,0 +1,47 @@
+package dmap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/olric-data/olric/internal/testcluster"
+	"github.com/olric-data/olric/internal/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDmap_MGet(t *testing.T) {
+	cluster := testcluster.New(NewService)
+	s := cluster.AddMember(nil).(*Service)
+	defer cluster.Shutdown()
+
+	ctx := context.Background()
+
+	dm, err := s.NewDMap("mydmap")
+	require.NoError(t, err)
+
+	keysInserted := make([]string, 0, 10)
+
+	expected := make(map[string]string)
+
+	for i := 0; i < 10; i++ {
+		k := testutil.ToKey(i)
+		v := testutil.ToVal(i)
+
+		err = dm.Put(ctx, k, v, nil)
+		require.NoError(t, err)
+
+		keysInserted = append(keysInserted, k)
+		expected[k] = string(v)
+	}
+
+	got := dm.MGet(ctx, keysInserted...)
+
+	require.Len(t, got, len(keysInserted))
+
+	for _, k := range keysInserted {
+		v, ok := got[k]
+		require.True(t, ok, "missing key: %s", k)
+
+		require.Equal(t, expected[k], v, "mismatch for key: %s", k)
+	}
+}


### PR DESCRIPTION
only a suggestion for adding mget i can optimize it further by maybe doing : grouping keys by owner and then in 1 single request get all the keys 