### PR TITLE
Fix silent data loss in DMap.Delete with multi-key/multi-owner deletes

### DIFF
--- a/internal/dmap/delete.go
+++ b/internal/dmap/delete.go
@@ -17,6 +17,7 @@ package dmap
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 
 	"github.com/olric-data/olric/internal/cluster/partitions"
 	"github.com/olric-data/olric/internal/discovery"
@@ -147,26 +148,44 @@ func (dm *DMap) deleteKeys(ctx context.Context, keys ...string) (int, error) {
 		members[member] = append(members[member], key)
 	}
 
+	// Fan out to every owner instead of stopping at the first remote one -
+	// see the errgroup pattern used by deleteBackupOnCluster/destroyOnCluster.
+	var count int64
+	var g errgroup.Group
 	for member, distributedKeys := range members {
+		member, distributedKeys := member, distributedKeys
 		if member.CompareByName(dm.s.rt.This()) {
-			for _, key := range distributedKeys {
-				if err := dm.deleteKey(key); err != nil {
-					return 0, err
+			g.Go(func() error {
+				for _, key := range distributedKeys {
+					if err := dm.deleteKey(key); err != nil {
+						return err
+					}
 				}
-			}
-		} else {
+				atomic.AddInt64(&count, int64(len(distributedKeys)))
+				return nil
+			})
+			continue
+		}
+
+		g.Go(func() error {
 			cmd := protocol.NewDel(dm.name, distributedKeys...).Command(dm.s.ctx)
 			rc := dm.s.client.Get(member.String())
-			err := rc.Process(ctx, cmd)
-			if err != nil {
-				return 0, protocol.ConvertError(err)
+			if err := rc.Process(ctx, cmd); err != nil {
+				return protocol.ConvertError(err)
 			}
-
-			return 0, protocol.ConvertError(cmd.Err())
-		}
+			if err := cmd.Err(); err != nil {
+				return protocol.ConvertError(err)
+			}
+			atomic.AddInt64(&count, int64(len(distributedKeys)))
+			return nil
+		})
 	}
 
-	return len(keys), nil
+	if err := g.Wait(); err != nil {
+		return 0, err
+	}
+
+	return int(count), nil
 }
 
 // Delete deletes the value for the given key. Delete will not return error if key doesn't exist. It's thread-safe.

--- a/internal/dmap/delete_test.go
+++ b/internal/dmap/delete_test.go
@@ -97,6 +97,54 @@ func TestDMap_Delete_Cluster(t *testing.T) {
 	}
 }
 
+func TestDMap_Delete_MultiKeyDifferentRemoteOwners(t *testing.T) {
+	cluster := testcluster.New(NewService)
+	s1 := cluster.AddMember(nil).(*Service)
+	cluster.AddMember(nil)
+	cluster.AddMember(nil)
+	defer cluster.Shutdown()
+
+	dm1, err := s1.NewDMap("mymap")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	const keyCount = 30
+	for i := 0; i < keyCount; i++ {
+		err = dm1.Put(ctx, testutil.ToKey(i), testutil.ToVal(i), nil)
+		require.NoError(t, err)
+	}
+
+	// Sanity check: the keys must hash to at least two different owners other
+	// than s1 itself. Otherwise, deleteKeys' per-owner fan-out only has a
+	// single remote entry and this test wouldn't exercise the multi-owner
+	// code path where a bug could silently drop keys past the first remote
+	// owner.
+	remoteOwners := make(map[string]struct{})
+	for i := 0; i < keyCount; i++ {
+		hkey := partitions.HKey("mymap", testutil.ToKey(i))
+		owner := s1.primary.PartitionByHKey(hkey).Owner()
+		if !owner.CompareByName(s1.rt.This()) {
+			remoteOwners[owner.String()] = struct{}{}
+		}
+	}
+	require.GreaterOrEqual(t, len(remoteOwners), 2,
+		"test setup must distribute keys across at least two remote owners")
+
+	keys := make([]string, keyCount)
+	for i := 0; i < keyCount; i++ {
+		keys[i] = testutil.ToKey(i)
+	}
+
+	count, err := dm1.Delete(ctx, keys...)
+	require.NoError(t, err)
+	require.Equal(t, keyCount, count)
+
+	for i := 0; i < keyCount; i++ {
+		_, err = dm1.Get(ctx, testutil.ToKey(i))
+		require.ErrorIs(t, err, ErrKeyNotFound)
+	}
+}
+
 func TestDMap_Delete_Lookup(t *testing.T) {
 	cluster := testcluster.New(NewService)
 	s1 := cluster.AddMember(nil).(*Service)


### PR DESCRIPTION
Fixes #286

## Summary
- `deleteKeys` returned unconditionally after the first remote owner
  (success or error), skipping remaining remote owners in multi-key
  deletes and silently leaving their keys undeleted.
- Fan-out now uses `errgroup.Group`, matching the pattern already used
  by `deleteBackupOnCluster`/`destroyOnCluster` in the same file: every
  owner is attempted, first error is returned only after all owners
  have completed. Returned count reflects keys actually processed.

## Test plan
- [x] Added `TestDMap_Delete_MultiKeyDifferentRemoteOwners`, confirmed
      it fails on master and passes with this fix
- [x] `go test ./internal/dmap/... -run TestDMap_Delete` (8/8 pass)
- [x] `go test ./...` (539/539 pass, 35 packages)
- [x] `go test ./internal/dmap/... -race` (97/97 pass, no races)