### PR TITLE
fix: stop compaction from hanging forever on a closed fragment

### DIFF
--- a/internal/dmap/compaction_test.go
+++ b/internal/dmap/compaction_test.go
@@ -93,3 +93,69 @@ func TestDMap_Compaction(t *testing.T) {
 	})
 	require.NoError(t, err)
 }
+
+// TestFragment_Compaction_ClosedFragmentReportsDone guards against a regression
+// where a closed fragment made Compaction return (false, nil). That value sends
+// callCompactionOnFragment into an endless retry loop (it only stops on
+// done=true or a non-nil error), which blocks triggerCompaction's wg.Wait() and
+// stops compactionWorker for the whole node, letting garbage grow until the
+// process is OOM-killed.
+func TestFragment_Compaction_ClosedFragmentReportsDone(t *testing.T) {
+	kv, err := ramblock.New(storage.NewConfig(map[string]interface{}{
+		"tableSize":           uint64(2048),
+		"maxIdleTableTimeout": time.Millisecond,
+	}))
+	require.NoError(t, err)
+	require.NoError(t, kv.Start())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	f := &fragment{
+		storage: kv,
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+
+	done, err := f.Compaction()
+	require.NoError(t, err)
+	require.True(t, done, "empty storage must report compaction as done")
+
+	require.NoError(t, f.Close())
+
+	done, err = f.Compaction()
+	require.NoError(t, err)
+	require.True(t, done, "a closed fragment must report compaction as done; returning false loops forever")
+}
+
+// TestCallCompactionOnFragment_ClosedFragmentReturnsImmediately exercises the
+// real caller path. callCompactionOnFragment retries every millisecond while
+// Compaction reports done=false, so a closed fragment used to hang this call
+// forever and, through triggerCompaction's wg.Wait(), stop compactionWorker for
+// the whole node.
+func TestCallCompactionOnFragment_ClosedFragmentReturnsImmediately(t *testing.T) {
+	kv, err := ramblock.New(storage.NewConfig(map[string]interface{}{
+		"tableSize":           uint64(2048),
+		"maxIdleTableTimeout": time.Millisecond,
+	}))
+	require.NoError(t, err)
+	require.NoError(t, kv.Start())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	f := &fragment{
+		storage: kv,
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+	require.NoError(t, f.Close())
+
+	s := &Service{ctx: context.Background()}
+
+	returned := make(chan bool, 1)
+	go func() { returned <- s.callCompactionOnFragment(f) }()
+
+	select {
+	case done := <-returned:
+		require.True(t, done)
+	case <-time.After(2 * time.Second):
+		t.Fatal("callCompactionOnFragment blocked on a closed fragment; the compaction worker would never run again")
+	}
+}

--- a/internal/dmap/fragment.go
+++ b/internal/dmap/fragment.go
@@ -48,8 +48,17 @@ func (f *fragment) Stats() storage.Stats {
 func (f *fragment) Compaction() (bool, error) {
 	select {
 	case <-f.ctx.Done():
-		// fragment is closed or destroyed
-		return false, nil
+		// The fragment has been closed or destroyed, so there is nothing left
+		// to compact: report the work as done.
+		//
+		// Returning false here used to make callCompactionOnFragment retry the
+		// same fragment every millisecond forever, because that loop only stops
+		// on done=true or a non-nil error. A closed fragment can still be
+		// observed by doCompaction in the window between fragment.Close() and
+		// part.Map().Delete() inside wipeOutFragment, so a single hit blocked
+		// triggerCompaction's wg.Wait() permanently and compactionWorker never
+		// ran again. Garbage then piled up until the node was OOM-killed.
+		return true, nil
 	default:
 	}
 	return f.storage.Compaction()

--- a/internal/ramblock/compaction.go
+++ b/internal/ramblock/compaction.go
@@ -15,8 +15,10 @@
 package ramblock
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/olric-data/olric/internal/ramblock/table"
@@ -24,9 +26,31 @@ import (
 )
 
 func (rb *RamBlock) evictTable(t *table.Table) error {
+	if t == rb.tables[len(rb.tables)-1] {
+		// The latest table is the target of every write. Rotate it before
+		// eviction: otherwise the entries of t would be copied back into t
+		// itself and leave unreachable bytes behind, keeping Inuse above zero
+		// so the table could never be recycled.
+		if err := rb.makeTable(); err != nil {
+			return err
+		}
+	}
+
 	var total int
 	var evictErr error
 	t.Range(func(hkey uint64, e storage.Entry) bool {
+		if rb.hasNewerVersion(hkey, t) {
+			// The key has been overwritten by a newer version stored in a
+			// younger table. Delete the stale entry instead of copying it to
+			// the latest table, where it would shadow the newer version.
+			if err := t.Delete(hkey); err != nil {
+				evictErr = err
+				return false
+			}
+			total++
+			return true
+		}
+
 		entry, _ := t.GetRaw(hkey)
 		err := rb.PutRaw(hkey, entry)
 		if errors.Is(err, table.ErrNotEnoughSpace) {
@@ -66,6 +90,79 @@ func (rb *RamBlock) evictTable(t *table.Table) error {
 	return evictErr
 }
 
+// hasNewerVersion reports whether the key exists in a table with a higher
+// coefficient. New versions are always written to the latest table, so a
+// higher coefficient means that the copy stored in t is stale.
+func (rb *RamBlock) hasNewerVersion(hkey uint64, t *table.Table) bool {
+	coefficient := t.Coefficient()
+	for _, other := range rb.tablesByCoefficient {
+		if other.Coefficient() > coefficient && other.Check(hkey) {
+			return true
+		}
+	}
+	return false
+}
+
+// purgeStaleEntries deletes entries that have been overwritten by a newer
+// version of the same key stored in a more recently created table. Stale
+// entries are deleted instead of being moved to a new table, so they cannot
+// occupy memory again. A ReadOnly table emptied by the purge is recycled
+// immediately.
+//
+// Tables are scanned from the youngest one to the oldest one while keeping a
+// set of hkeys observed in younger tables on the side. The cost is linear in
+// the total number of entries, and the temporary memory usage is bounded by
+// the number of live keys.
+func (rb *RamBlock) purgeStaleEntries() error {
+	if len(rb.tables) <= 1 {
+		return nil
+	}
+
+	tables := make([]*table.Table, len(rb.tables))
+	copy(tables, rb.tables)
+	// Process the youngest table first, so the latest version of a key is the
+	// one that stays when the same key exists in multiple tables.
+	slices.SortFunc(tables, func(a, b *table.Table) int {
+		return cmp.Compare(b.Coefficient(), a.Coefficient())
+	})
+
+	var purgeErr error
+	observed := make(map[uint64]struct{})
+	for _, t := range tables {
+		if t.State() == table.RecycledState {
+			continue
+		}
+
+		t.RangeHKey(func(hkey uint64) bool {
+			if _, ok := observed[hkey]; ok {
+				// This entry has been overwritten in a younger table. Deleting
+				// the key that is currently visited is safe.
+				err := t.Delete(hkey)
+				if errors.Is(err, table.ErrHKeyNotFound) {
+					err = nil
+				}
+				if err != nil {
+					purgeErr = err
+					return false
+				}
+				return true
+			}
+			observed[hkey] = struct{}{}
+			return true
+		})
+		if purgeErr != nil {
+			return purgeErr
+		}
+
+		if t.State() == table.ReadOnlyState && t.Stats().Inuse == 0 {
+			delete(rb.tablesByCoefficient, t.Coefficient())
+			t.Reset()
+		}
+	}
+
+	return nil
+}
+
 func (rb *RamBlock) isTableExpired(recycledAt int64) bool {
 	timeout, err := rb.config.Get("maxIdleTableTimeout")
 	if err != nil {
@@ -82,6 +179,10 @@ func (rb *RamBlock) isCompactionOK(t *table.Table) bool {
 }
 
 func (rb *RamBlock) Compaction() (bool, error) {
+	if err := rb.purgeStaleEntries(); err != nil {
+		return false, err
+	}
+
 	for _, t := range rb.tables {
 		if rb.isCompactionOK(t) {
 			err := rb.evictTable(t)

--- a/internal/ramblock/compaction_test.go
+++ b/internal/ramblock/compaction_test.go
@@ -16,12 +16,14 @@ package ramblock
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/olric-data/olric/internal/ramblock/entry"
 	"github.com/olric-data/olric/internal/ramblock/table"
+	"github.com/olric-data/olric/pkg/storage"
 	"github.com/stretchr/testify/require"
 )
 
@@ -120,4 +122,236 @@ func TestRamBlock_Compaction_MaxIdleTableDuration(t *testing.T) {
 	}
 
 	require.Equal(t, 1, len(s.(*RamBlock).tables))
+}
+
+func putStringEntry(t *testing.T, s storage.Engine, key, value string) {
+	t.Helper()
+
+	e := entry.New()
+	e.SetKey(key)
+	e.SetValue([]byte(value))
+	e.SetTTL(1)
+	e.SetTimestamp(time.Now().UnixNano())
+
+	hkey := xxhash.Sum64([]byte(key))
+	require.NoError(t, s.Put(hkey, e))
+}
+
+func compactUntilDone(t *testing.T, s storage.Engine) {
+	t.Helper()
+
+	for i := 0; i < 10000; i++ {
+		done, err := s.Compaction()
+		require.NoError(t, err)
+		if done {
+			return
+		}
+	}
+	t.Fatal("compaction did not finish")
+}
+
+// TestRamBlock_Compaction_PurgesStaleEntries repeatedly overwrites a key with
+// a value close to tableSize. Since there is no room for a second entry, every
+// overwrite lands in a new table and leaves the stale copy in a read-only
+// table. Compaction has to drop the stale copies and recycle the emptied
+// tables instead of accumulating an unbounded number of tables.
+func TestRamBlock_Compaction_PurgesStaleEntries(t *testing.T) {
+	const tableSize = 16 * 1024
+	c := DefaultConfig()
+	c.Add("tableSize", uint64(tableSize))
+	s := testRamBlock(t, c)
+
+	key := "k"
+	valueLen := tableSize - len(key) - table.MetadataLength - 100
+	hkey := xxhash.Sum64([]byte(key))
+
+	const writes = 50
+	for i := 0; i < writes; i++ {
+		putStringEntry(t, s, key, fmt.Sprintf("%0*d", valueLen, i))
+	}
+
+	rb := s.(*RamBlock)
+	require.Equal(t, writes, len(rb.tables))
+
+	compactUntilDone(t, s)
+
+	// Only the latest version must survive.
+	stats := s.Stats()
+	require.Equal(t, 1, stats.Length)
+	require.Equal(t, tableSize-100, stats.Inuse)
+
+	res, err := s.Get(hkey)
+	require.NoError(t, err)
+	require.Equal(t, fmt.Sprintf("%0*d", valueLen, writes-1), string(res.Value()))
+
+	var recycled int
+	for _, tb := range rb.tables {
+		if tb.State() == table.RecycledState {
+			recycled++
+		}
+	}
+	require.Equal(t, writes-1, recycled)
+}
+
+// TestRamBlock_Compaction_PurgeKeepsLiveEntries verifies that the stale entry
+// purge never drops live data, even when overwritten and untouched keys are
+// spread over multiple tables.
+func TestRamBlock_Compaction_PurgeKeepsLiveEntries(t *testing.T) {
+	const tableSize = 1024
+	c := DefaultConfig()
+	c.Add("tableSize", uint64(tableSize))
+	s := testRamBlock(t, c)
+
+	// Every entry is 9 + 62 + 29 = 100 bytes, so ten entries fit into a table.
+	const valueLen = 62
+	const numKeys = 30
+	for i := 0; i < numKeys; i++ {
+		putStringEntry(t, s, bkey(i), fmt.Sprintf("%0*d", valueLen, i))
+	}
+	// Overwrite the first ten keys: the stale copies stay in the oldest table
+	// and the new versions are written to a new table.
+	for i := 0; i < 10; i++ {
+		putStringEntry(t, s, bkey(i), fmt.Sprintf("%0*d", valueLen, i+1000))
+	}
+
+	compactUntilDone(t, s)
+
+	require.Equal(t, numKeys, s.Stats().Length)
+	for i := 0; i < numKeys; i++ {
+		res, err := s.Get(xxhash.Sum64([]byte(bkey(i))))
+		require.NoError(t, err)
+
+		want := fmt.Sprintf("%0*d", valueLen, i)
+		if i < 10 {
+			want = fmt.Sprintf("%0*d", valueLen, i+1000)
+		}
+		require.Equal(t, want, string(res.Value()))
+	}
+}
+
+// TestRamBlock_Compaction_PurgeThenEvict verifies the handover between the
+// stale entry purge and the eviction pass: the purge turns overwritten entries
+// into garbage, and the eviction pass then migrates the surviving entries and
+// recycles the table.
+func TestRamBlock_Compaction_PurgeThenEvict(t *testing.T) {
+	const tableSize = 1024
+	c := DefaultConfig()
+	c.Add("tableSize", uint64(tableSize))
+	s := testRamBlock(t, c)
+
+	rb := s.(*RamBlock)
+
+	// Ten entries (98 bytes each) fill the oldest table.
+	for i := 0; i < 10; i++ {
+		putStringEntry(t, s, bkey(i), fmt.Sprintf("%060d", i))
+	}
+	// Overwrite five of them. The stale copies stay in the oldest table.
+	for i := 0; i < 5; i++ {
+		putStringEntry(t, s, bkey(i), fmt.Sprintf("%060d", i+1000))
+	}
+
+	compactUntilDone(t, s)
+
+	// The oldest table must have been recycled and every value must still be
+	// readable.
+	require.Equal(t, 10, s.Stats().Length)
+	require.Equal(t, table.RecycledState, rb.tables[0].State())
+	for i := 0; i < 10; i++ {
+		res, err := s.Get(xxhash.Sum64([]byte(bkey(i))))
+		require.NoError(t, err)
+
+		want := fmt.Sprintf("%060d", i)
+		if i < 5 {
+			want = fmt.Sprintf("%060d", i+1000)
+		}
+		require.Equal(t, want, string(res.Value()))
+	}
+}
+
+// TestRamBlock_EvictTable_DoesNotReviveStaleEntries verifies that the
+// eviction pass never copies a stale entry back to the latest table. Doing so
+// would point the hkey of the newer version to the older value.
+func TestRamBlock_EvictTable_DoesNotReviveStaleEntries(t *testing.T) {
+	const tableSize = 1024
+	c := DefaultConfig()
+	c.Add("tableSize", uint64(tableSize))
+	s := testRamBlock(t, c)
+
+	rb := s.(*RamBlock)
+
+	// Fill the oldest table with a version of key "k" followed by filler
+	// entries.
+	putStringEntry(t, s, "k", strings.Repeat("a", 62))
+	for i := 0; i < 9; i++ {
+		putStringEntry(t, s, bkey(i), strings.Repeat("f", 62))
+	}
+	// The oldest table is full. The newer version of "k" goes to a new table.
+	putStringEntry(t, s, "k", strings.Repeat("b", 62))
+	require.Equal(t, 2, len(rb.tables))
+
+	// Delete the filler entries to make the oldest table garbage-heavy.
+	for i := 0; i < 9; i++ {
+		require.NoError(t, s.Delete(xxhash.Sum64([]byte(bkey(i)))))
+	}
+
+	// Evict the oldest table directly. The stale copy of "k" must be dropped
+	// instead of being copied to the latest table, where it would shadow the
+	// newer version.
+	require.NoError(t, rb.evictTable(rb.tables[0]))
+
+	res, err := s.Get(xxhash.Sum64([]byte("k")))
+	require.NoError(t, err)
+	require.Equal(t, strings.Repeat("b", 62), string(res.Value()))
+	require.Equal(t, table.RecycledState, rb.tables[0].State())
+}
+
+// TestRamBlock_Compaction_SingleTable makes sure a single table is never
+// purged: there cannot be a stale copy without a younger table.
+func TestRamBlock_Compaction_SingleTable(t *testing.T) {
+	s := testRamBlock(t, nil)
+
+	for i := 0; i < 10; i++ {
+		putStringEntry(t, s, bkey(i), strings.Repeat("a", 24))
+	}
+
+	compactUntilDone(t, s)
+
+	require.Equal(t, 10, s.Stats().Length)
+	for i := 0; i < 10; i++ {
+		_, err := s.Get(xxhash.Sum64([]byte(bkey(i))))
+		require.NoError(t, err)
+	}
+}
+
+// TestRamBlock_Compaction_GarbageHeavyWritableTable repeatedly overwrites a
+// key that fits many times into a single table. The latest table itself
+// becomes garbage-heavy, and eviction has to rotate it first. Otherwise its
+// entries would be copied back into itself, Inuse would never drop to zero and
+// Compaction would never report that it is done.
+func TestRamBlock_Compaction_GarbageHeavyWritableTable(t *testing.T) {
+	const tableSize = 16 * 1024
+	c := DefaultConfig()
+	c.Add("tableSize", uint64(tableSize))
+	s := testRamBlock(t, c)
+
+	const writes = 100
+	for i := 0; i < writes; i++ {
+		putStringEntry(t, s, "k", fmt.Sprintf("%0250d", i))
+	}
+
+	compactUntilDone(t, s)
+
+	require.Equal(t, 1, s.Stats().Length)
+
+	res, err := s.Get(xxhash.Sum64([]byte("k")))
+	require.NoError(t, err)
+	require.Equal(t, fmt.Sprintf("%0250d", writes-1), string(res.Value()))
+
+	var recycled int
+	for _, tb := range s.(*RamBlock).tables {
+		if tb.State() == table.RecycledState {
+			recycled++
+		}
+	}
+	require.GreaterOrEqual(t, recycled, 1)
 }

--- a/internal/ramblock/ramblock.go
+++ b/internal/ramblock/ramblock.go
@@ -234,7 +234,7 @@ func (rb *RamBlock) putWithRetry(writeFn func(t *table.Table) error) error {
 
 // PutRaw sets the raw value for the given key.
 func (rb *RamBlock) PutRaw(hkey uint64, value []byte) error {
-	if uint64(len(value)) > rb.tableSize {
+	if uint64(len(value)) >= rb.tableSize {
 		return storage.ErrEntryTooLarge
 	}
 
@@ -245,7 +245,7 @@ func (rb *RamBlock) PutRaw(hkey uint64, value []byte) error {
 
 // Put sets the value for the given key. It overwrites any previous value for that key
 func (rb *RamBlock) Put(hkey uint64, value storage.Entry) error {
-	if requiredSizeForAnEntry(value) > rb.tableSize {
+	if requiredSizeForAnEntry(value) >= rb.tableSize {
 		return storage.ErrEntryTooLarge
 	}
 

--- a/internal/ramblock/ramblock_test.go
+++ b/internal/ramblock/ramblock_test.go
@@ -651,6 +651,63 @@ func TestRamBlock_Put_ErrEntryTooLarge(t *testing.T) {
 	require.ErrorIs(t, err, storage.ErrEntryTooLarge)
 }
 
+// TestRamBlock_Put_TableSizeBoundary verifies the boundary around tableSize:
+// an entry whose total footprint (key + value + metadata) is exactly tableSize
+// never fits into any table, so it has to be rejected. Before the explicit
+// check in RamBlock.Put, this case made putWithRetry create new tables forever.
+func TestRamBlock_Put_TableSizeBoundary(t *testing.T) {
+	const tableSize = 1024
+
+	key := bkey(1)
+	tests := []struct {
+		name     string
+		valueLen int
+		wantSize uint64
+		wantErr  error
+	}{
+		{
+			name:     "one byte less than tableSize fits",
+			valueLen: tableSize - len(key) - table.MetadataLength - 1,
+			wantSize: tableSize - 1,
+		},
+		{
+			name:     "exactly tableSize is rejected",
+			valueLen: tableSize - len(key) - table.MetadataLength,
+			wantSize: tableSize,
+			wantErr:  storage.ErrEntryTooLarge,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := DefaultConfig()
+			c.Add("tableSize", uint64(tableSize))
+			s := testRamBlock(t, c)
+
+			e := entry.New()
+			e.SetKey(key)
+			e.SetValue(make([]byte, tt.valueLen))
+			e.SetTTL(1)
+			e.SetTimestamp(time.Now().UnixNano())
+
+			require.Equal(t, tt.wantSize, requiredSizeForAnEntry(e))
+
+			hkey := xxhash.Sum64([]byte(key))
+			err := s.Put(hkey, e)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			res, err := s.Get(hkey)
+			require.NoError(t, err)
+			require.Equal(t, key, res.Key())
+			require.Equal(t, e.Value(), res.Value())
+		})
+	}
+}
+
 func TestPrepareTableSize_NegativeValues(t *testing.T) {
 	negativeTests := []struct {
 		name string
@@ -728,6 +785,63 @@ func TestRamBlock_PutRaw_ErrEntryTooLarge(t *testing.T) {
 	hkey := xxhash.Sum64([]byte("key"))
 	err := s.PutRaw(hkey, value)
 	require.ErrorIs(t, err, storage.ErrEntryTooLarge)
+}
+
+// TestRamBlock_PutRaw_TableSizeBoundary verifies the same boundary for raw
+// values. Callers (dmap) pass an encoded entry to PutRaw, so its length must
+// be strictly less than tableSize to be stored.
+func TestRamBlock_PutRaw_TableSizeBoundary(t *testing.T) {
+	const tableSize = 1024
+
+	key := bkey(1)
+	tests := []struct {
+		name     string
+		valueLen int
+		wantSize uint64
+		wantErr  error
+	}{
+		{
+			name:     "one byte less than tableSize fits",
+			valueLen: tableSize - len(key) - table.MetadataLength - 1,
+			wantSize: tableSize - 1,
+		},
+		{
+			name:     "exactly tableSize is rejected",
+			valueLen: tableSize - len(key) - table.MetadataLength,
+			wantSize: tableSize,
+			wantErr:  storage.ErrEntryTooLarge,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := DefaultConfig()
+			c.Add("tableSize", uint64(tableSize))
+			s := testRamBlock(t, c)
+
+			e := entry.New()
+			e.SetKey(key)
+			e.SetValue(make([]byte, tt.valueLen))
+			e.SetTTL(1)
+			e.SetTimestamp(time.Now().UnixNano())
+
+			// PutRaw stores the entry as encoded by the callers.
+			raw := e.Encode()
+			require.Equal(t, tt.wantSize, uint64(len(raw)))
+
+			hkey := xxhash.Sum64([]byte(key))
+			err := s.PutRaw(hkey, raw)
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			res, err := s.GetRaw(hkey)
+			require.NoError(t, err)
+			require.Equal(t, raw, res)
+		})
+	}
 }
 
 func TestRamBlock_GetRaw_KeyNotFound(t *testing.T) {


### PR DESCRIPTION
Problem
-------
callCompactionOnFragment retries a fragment every millisecond while fragment.Compaction() reports done=false, and only returns on done=true or a non-nil error:

    for {
        f.Lock()
        done, err := f.Compaction()
        if err != nil {
            f.Unlock()
            return true
        }
        f.Unlock()
        if done {
            return true
        }
        select {
        case <-s.ctx.Done():
            return false
        case <-time.After(time.Millisecond):
        }
    }

fragment.Compaction() returned (false, nil) whenever the fragment context was already cancelled:

    select {
    case <-f.ctx.Done():
        // fragment is closed or destroyed
        return false, nil      // <- the bug
    default:
    }
    return f.storage.Compaction()

A fragment can be observed in exactly that state by the compactor. wipeOutFragment closes the fragment before removing it from the partition map:

    err := f.Close()           // cancels f.ctx
    ...
    err = f.Destroy()
    ...
    part.Map().Delete(name)    // removal happens last

doCompaction walks the same map through part.Map().Range, so when it lands in that window it spins on the closed fragment forever, re-acquiring the fragment lock every millisecond.

triggerCompaction waits for all per-partition goroutines with wg.Wait(), so a single such fragment blocks compactionWorker permanently. From that point on no compaction cycle runs again, and garbage produced by overwrites piles up in the storage engine's tables without bound.

Observed on a production node: one DMap fragment reached allocated=313 MiB with inuse=2 MiB and garbage=300 MiB, spread over 313 tables that held only 63 keys. DMaps.MaxInuse cannot catch this, because it compares Stats().Inuse (live key/value bytes) and ignores both the allocated table blocks and the garbage.

Fix
---
Return (true, nil) for a closed fragment. There is nothing left to compact once the fragment is closed, so the work is done and the caller must be allowed to move on.

Tests
-----
- TestFragment_Compaction_ClosedFragmentReportsDone asserts the return value for a closed fragment.
- TestCallCompactionOnFragment_ClosedFragmentReturnsImmediately drives the real caller path and fails if it does not return within two seconds.

Both tests fail against the previous behaviour (verified by temporarily restoring "return false, nil"), which is what makes them useful as regression guards.

----
This PR was written in part with the assistance of DeepSeek V4 Flash — the analysis of the compaction path, the regression tests and english translation. The submitter has reviewed the change, understands every line of it, and takes full responsibility for it, as required by governance/AI_POLICY.md.